### PR TITLE
Respect trim level for members of non-public types

### DIFF
--- a/src/InheritDoc/InheritDocProcessor.cs
+++ b/src/InheritDoc/InheritDocProcessor.cs
@@ -190,7 +190,7 @@ internal class InheritDocProcessor
 
 				// If no docs for public explicit interface implementation, inject them
 				// including the whitespace they would have had if they had been there.
-				if ((om?.DeclaringType.GetApiLevel() ?? ApiLevel.None) == ApiLevel.Public && t.GetApiLevel() == ApiLevel.Public && !findDocsByID(docMembers, memID).Any())
+				if ((om?.DeclaringType.GetApiLevel() ?? ApiLevel.None) == ApiLevel.Public && t.GetApiLevel() > trimLevel && !findDocsByID(docMembers, memID).Any())
 					docMembers.Add(
 						new XText("    "),
 							new XElement(DocElementNames.Member,

--- a/tests/InheritDoc.Test/DocTests.cs
+++ b/tests/InheritDoc.Test/DocTests.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 namespace InheritDocTest
@@ -252,38 +251,17 @@ internal class ImplementsICollection : ICollection<string>
 	bool ICollection<string>.IsReadOnly => throw new NotImplementedException();
 
 	/// <inheritdoc />
-	public void Add(string item)
-	{
-		throw new NotImplementedException();
-	}
+	public void Add(string item) => throw new NotImplementedException();
 
-	void ICollection<string>.Clear()
-	{
-		throw new NotImplementedException();
-	}
+	void ICollection<string>.Clear() => throw new NotImplementedException();
 
-	bool ICollection<string>.Contains(string item)
-	{
-		throw new NotImplementedException();
-	}
+	bool ICollection<string>.Contains(string item) => throw new NotImplementedException();
 
-	void ICollection<string>.CopyTo(string[] array, int arrayIndex)
-	{
-		throw new NotImplementedException();
-	}
+	void ICollection<string>.CopyTo(string[] array, int arrayIndex) => throw new NotImplementedException();
 
-	IEnumerator<string> IEnumerable<string>.GetEnumerator()
-	{
-		throw new NotImplementedException();
-	}
+	IEnumerator<string> IEnumerable<string>.GetEnumerator() => throw new NotImplementedException();
 
-	IEnumerator IEnumerable.GetEnumerator()
-	{
-		throw new NotImplementedException();
-	}
+	IEnumerator IEnumerable.GetEnumerator() => throw new NotImplementedException();
 
-	bool ICollection<string>.Remove(string item)
-	{
-		throw new NotImplementedException();
-	}
+	bool ICollection<string>.Remove(string item) => throw new NotImplementedException();
 }

--- a/tests/InheritDoc.Test/DocTests.cs
+++ b/tests/InheritDoc.Test/DocTests.cs
@@ -2,7 +2,9 @@
 #pragma warning disable CS0659
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 namespace InheritDocTest
@@ -240,4 +242,48 @@ public class W
 
 	/// <inheritdoc />
 	public void NotInherited() { }
+}
+
+internal class ImplementsICollection : ICollection<string>
+{
+	/// <inheritdoc />
+	int ICollection<string>.Count => throw new NotImplementedException();
+
+	bool ICollection<string>.IsReadOnly => throw new NotImplementedException();
+
+	/// <inheritdoc />
+	public void Add(string item)
+	{
+		throw new NotImplementedException();
+	}
+
+	void ICollection<string>.Clear()
+	{
+		throw new NotImplementedException();
+	}
+
+	bool ICollection<string>.Contains(string item)
+	{
+		throw new NotImplementedException();
+	}
+
+	void ICollection<string>.CopyTo(string[] array, int arrayIndex)
+	{
+		throw new NotImplementedException();
+	}
+
+	IEnumerator<string> IEnumerable<string>.GetEnumerator()
+	{
+		throw new NotImplementedException();
+	}
+
+	IEnumerator IEnumerable.GetEnumerator()
+	{
+		throw new NotImplementedException();
+	}
+
+	bool ICollection<string>.Remove(string item)
+	{
+		throw new NotImplementedException();
+	}
 }


### PR DESCRIPTION
# Summary of Changes
Previously, the configured trimLevel was not respected when enumerating members of types that are included in the documentation xml, but their containing type is not public. This would result in IDT002 errors for members that should have been replaced with the `InheritDocTrimLevel` set to private or none. For builds with `-warnaserror`, this becomes a problem.