### PR TITLE
Add language option

### DIFF
--- a/src/InheritDoc/InheritDocTask.cs
+++ b/src/InheritDoc/InheritDocTask.cs
@@ -33,8 +33,6 @@ public class InheritDocTask : Task
 			var trim = (ApiLevel)Math.Min((int)(Enum.TryParse<ApiLevel>(TrimLevel, true, out var t) ? t : ApiLevel.Internal), (int)ApiLevel.Internal);
 			var language = string.IsNullOrWhiteSpace(Language) ? null : new CultureInfo(Language);
 
-			System.Diagnostics.Debugger.Launch();
-
 			Log.LogCommandLine(MessageImportance.Normal,
 				typeof(InheritDocTask).Assembly.GetName().FullName +
 				Environment.NewLine + nameof(AssemblyPath) + ": " + AssemblyPath +

--- a/src/InheritDoc/package/build/SauceControl.InheritDoc.targets
+++ b/src/InheritDoc/package/build/SauceControl.InheritDoc.targets
@@ -19,7 +19,7 @@
 			<FileWrites Include="@(_InheritDocBackupFile)" Condition="Exists('@(_InheritDocBackupFile)')" />
 		</ItemGroup>
 
-		<InheritDocTask AssemblyPath="@(IntermediateAssembly)" InDocPath="@(_InheritDocBackupFile)" OutDocPath="@(DocFileItem)" RefAssemblyPaths="@(_ResolveAssemblyReferenceResolvedFiles)" AdditionalDocPaths="@(InheritDocReference)" NoWarn="$(NoWarn)" TrimLevel="$(InheritDocTrimLevel)" />
+		<InheritDocTask AssemblyPath="@(IntermediateAssembly)" InDocPath="@(_InheritDocBackupFile)" OutDocPath="@(DocFileItem)" RefAssemblyPaths="@(_ResolveAssemblyReferenceResolvedFiles)" AdditionalDocPaths="@(InheritDocReference)" NoWarn="$(NoWarn)" TrimLevel="$(InheritDocTrimLevel)" Language="$(InheritDocLanguage)" />
 
 	</Target>
 

--- a/tests/InheritDoc.Test/InheritDocTests.cs
+++ b/tests/InheritDoc.Test/InheritDocTests.cs
@@ -32,13 +32,13 @@ public class InheritDocTests
 		string outPathPrivateTrim = documentPath + ".privateTrim.after";
 
 		var log = new DebugLogger() as ILogger;
-		var (replaced, total, trimmed) = InheritDocProcessor.InheritDocs(assemblyPath, documentPath, outPath, referencePaths, Array.Empty<string>(), ApiLevel.Internal, log);
+		var (replaced, total, trimmed) = InheritDocProcessor.InheritDocs(assemblyPath, documentPath, outPath, referencePaths, Array.Empty<string>(), ApiLevel.Internal, null, log);
 		log.Write(ILogger.Severity.Message, $"replaced {replaced} of {total} and removed {trimmed}");
 
 		using var stmdoc = File.Open(outPath, FileMode.Open);
 		processedDocs = XDocument.Load(stmdoc, LoadOptions.PreserveWhitespace).Root.Element("members");
 
-		(replaced, total, trimmed) = InheritDocProcessor.InheritDocs(assemblyPath, documentPath, outPathPrivateTrim, referencePaths, Array.Empty<string>(), ApiLevel.Private, log);
+		(replaced, total, trimmed) = InheritDocProcessor.InheritDocs(assemblyPath, documentPath, outPathPrivateTrim, referencePaths, Array.Empty<string>(), ApiLevel.Private, null, log);
 		log.Write(ILogger.Severity.Message, $"replaced {replaced} of {total} and removed {trimmed}");
 
 		using var stmdocPrivateTrim = File.Open(outPathPrivateTrim, FileMode.Open);


### PR DESCRIPTION
 Hi, I recently had some time to implement the basic functionality of #6 myself. I used your input to make the language an option. When provided it now prioritizes the documentation in the language folders if found.
 
I had to do some additional changes because I ran in some issues with documentation from microsoft in .net5 where a documentation file for mscorlib.dll exists but there is no language version of it. There also are language versions of netstandard and System.Runtime.dll wich contain mostly the same members. So before my changes the documentation with the member that was first read was used because it was listed first in the xml-Container, wich in my case was mscorlib. Because of that I added a priority-flag to insert language files as well as explicitly provided XmlFiles at earlier postions to the xmldoc-Container since those should be prioritzed.

With this change it worked pretty fine but I only testet with .net5 so far.

Tell me what you think of the changes. Would be nice to have it on nuget.org^^