### PR TITLE
Enable incremental build.

### DIFF
--- a/src/InheritDoc/package/build/SauceControl.InheritDoc.targets
+++ b/src/InheritDoc/package/build/SauceControl.InheritDoc.targets
@@ -3,30 +3,34 @@
 
 	<PropertyGroup>
 		<InheritDocEnabled Condition="'$(InheritDocEnabled)'=='' and '$(Configuration)'!='debug' and '$(DesignTimeBuild)'!='true' and '$(BuildingForLiveUnitTesting)'!='true'">true</InheritDocEnabled>
-
-		<!-- Let the InheritDocTask work as a replacement for the task copying the documentation file to the output. -->
-		<CopyDocumentationFileToOutputDirectory Condition="'$(InheritDocEnabled)'=='true'">false</CopyDocumentationFileToOutputDirectory>
 	</PropertyGroup>
 
+	<!-- Ensure there is an intermediate doc file so InheritDocTask has distinct input and output, which allows the task to be skipped for incremental builds. -->
 	<ItemGroup Condition="'$(InheritDocEnabled)'=='true' and '@(DocFileItem)'=='@(FinalDocFile)'">
-		<!-- Force intermediate documentation file in order to enable incremental build. -->
 		<DocFileItem Remove="@(DocFileItem)"/>
 		<DocFileItem Include="@(FinalDocFile->'$(IntermediateOutputPath)%(Filename)%(Extension)')"/>
 	</ItemGroup>
 
 	<Target Name="_InheritDocPostProcess" AfterTargets="CoreCompile" DependsOnTargets="ResolveAssemblyReferences;CoreCompile;_CheckForCompileOutputs" Inputs="@(DocFileItem)" Outputs="@(FinalDocFile)" Condition="'$(InheritDocEnabled)'=='true' and '$(_DocumentationFileProduced)'=='true'">
 
-		<Message Importance="normal" Text="InheritDoc processing file: @(DocFileItem -> '%(Filename)%(Extension)')" />
+		<PropertyGroup Condition="'$(CopyDocumentationFileToOutputDirectory)'!='false'">
+			<_InheritDocCopyFile>true</_InheritDocCopyFile>
+			<CopyDocumentationFileToOutputDirectory>false</CopyDocumentationFileToOutputDirectory>
+		</PropertyGroup>
+
+		<Warning Condition="'$(_InheritDocCopyFile)'!='true'" Code="IDT901" Text="CopyDocumentationFileToOutputDirectory is set to false, so InheritDoc will not write to the output directory.  You should either set InheritDocEnabled to false or CopyDocumentationFileToOutputDirectory to true." />
+		<Message Condition="'$(_InheritDocCopyFile)'=='true'" Importance="normal" Text="InheritDoc processing file: @(DocFileItem->'%(Filename)%(Extension)')" />
 
 		<ItemGroup>
 			<InheritDocReference Condition="'$(TargetFramework)'=='netstandard2.0'" Include="$(_InheritDocNetStandardFallback)" />
 		</ItemGroup>
 
-		<InheritDocTask AssemblyPath="@(IntermediateAssembly)" InDocPath="@(DocFileItem)" OutDocPath="@(FinalDocFile)" RefAssemblyPaths="@(_ResolveAssemblyReferenceResolvedFiles)" AdditionalDocPaths="@(InheritDocReference)" NoWarn="$(NoWarn)" TrimLevel="$(InheritDocTrimLevel)" />
+		<InheritDocTask Condition="'$(_InheritDocCopyFile)'=='true'" AssemblyPath="@(IntermediateAssembly)" InDocPath="@(DocFileItem)" OutDocPath="@(FinalDocFile)" RefAssemblyPaths="@(_ResolveAssemblyReferenceResolvedFiles)" AdditionalDocPaths="@(InheritDocReference)" NoWarn="$(NoWarn)" TrimLevel="$(InheritDocTrimLevel)" />
 
 		<ItemGroup>
 			<FileWrites Condition="Exists('@(FinalDocFile)')" Include="@(FinalDocFile)" />
 		</ItemGroup>
+
 	</Target>
 
 </Project>

--- a/src/InheritDoc/package/build/SauceControl.InheritDoc.targets
+++ b/src/InheritDoc/package/build/SauceControl.InheritDoc.targets
@@ -3,11 +3,13 @@
 
 	<PropertyGroup>
 		<InheritDocEnabled Condition="'$(InheritDocEnabled)'=='' and '$(Configuration)'!='debug' and '$(DesignTimeBuild)'!='true' and '$(BuildingForLiveUnitTesting)'!='true'">true</InheritDocEnabled>
-		<CopyDocumentationFileToOutputDirectory Condition=" '$(InheritDocEnabled)' == 'true' ">false</CopyDocumentationFileToOutputDirectory>
+
+		<!-- Let the InheritDocTask work as a replacement for the task copying the documentation file to the output. -->
+		<CopyDocumentationFileToOutputDirectory Condition="'$(InheritDocEnabled)'=='true'">false</CopyDocumentationFileToOutputDirectory>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(InheritDocEnabled)'=='true' and '@(DocFileItem)'=='@(FinalDocFile)'">
-		<!-- Force intermediate documentation file -->
+		<!-- Force intermediate documentation file in order to enable incremental build. -->
 		<DocFileItem Remove="@(DocFileItem)"/>
 		<DocFileItem Include="@(FinalDocFile->'$(IntermediateOutputPath)%(Filename)%(Extension)')"/>
 	</ItemGroup>

--- a/src/InheritDoc/package/build/SauceControl.InheritDoc.targets
+++ b/src/InheritDoc/package/build/SauceControl.InheritDoc.targets
@@ -19,12 +19,14 @@
 		<Message Importance="normal" Text="InheritDoc processing file: @(DocFileItem -> '%(Filename)%(Extension)')" />
 
 		<ItemGroup>
-			<FileWrites Condition="Exists('@(FinalDocFile)')" Include="@(FinalDocFile)" />
 			<InheritDocReference Condition="'$(TargetFramework)'=='netstandard2.0'" Include="$(_InheritDocNetStandardFallback)" />
 		</ItemGroup>
 
 		<InheritDocTask AssemblyPath="@(IntermediateAssembly)" InDocPath="@(DocFileItem)" OutDocPath="@(FinalDocFile)" RefAssemblyPaths="@(_ResolveAssemblyReferenceResolvedFiles)" AdditionalDocPaths="@(InheritDocReference)" NoWarn="$(NoWarn)" TrimLevel="$(InheritDocTrimLevel)" />
 
+		<ItemGroup>
+			<FileWrites Condition="Exists('@(FinalDocFile)')" Include="@(FinalDocFile)" />
+		</ItemGroup>
 	</Target>
 
 </Project>

--- a/src/InheritDoc/package/build/SauceControl.InheritDoc.targets
+++ b/src/InheritDoc/package/build/SauceControl.InheritDoc.targets
@@ -3,24 +3,25 @@
 
 	<PropertyGroup>
 		<InheritDocEnabled Condition="'$(InheritDocEnabled)'=='' and '$(Configuration)'!='debug' and '$(DesignTimeBuild)'!='true' and '$(BuildingForLiveUnitTesting)'!='true'">true</InheritDocEnabled>
+		<CopyDocumentationFileToOutputDirectory Condition=" '$(InheritDocEnabled)' == 'true' ">false</CopyDocumentationFileToOutputDirectory>
 	</PropertyGroup>
 
-	<ItemGroup>
-		<_InheritDocBackupFile Include="@(DocFileItem -> '%(RootDir)%(Directory)%(Filename).original%(Extension)')" />
+	<ItemGroup Condition=" '$(InheritDocEnabled)' == 'true' ">
+		<!-- Force intermediate documentation file -->
+		<DocFileItem Remove="$(DocumentationFile)"/>
+		<DocFileItem Include="$(IntermediateOutputPath)$(AssemblyName).xml"/>
 	</ItemGroup>
 
-	<Target Name="_InheritDocPostProcess" AfterTargets="CoreCompile" DependsOnTargets="ResolveAssemblyReferences;CoreCompile;_CheckForCompileOutputs" Inputs="@(DocFileItem)" Outputs="@(_InheritDocBackupFile)" Condition="'$(InheritDocEnabled)'=='true' and '$(_DocumentationFileProduced)'=='true'">
+	<Target Name="_InheritDocPostProcess" AfterTargets="CoreCompile" DependsOnTargets="ResolveAssemblyReferences;CoreCompile;_CheckForCompileOutputs" Inputs="@(DocFileItem)" Outputs="@(FinalDocFile)" Condition="'$(InheritDocEnabled)'=='true' and '$(_DocumentationFileProduced)'=='true'">
 
 		<Message Importance="normal" Text="InheritDoc processing file: @(DocFileItem -> '%(Filename)%(Extension)')" />
 
-		<Copy SourceFiles="@(DocFileItem)" DestinationFiles="@(_InheritDocBackupFile)" />
-
 		<ItemGroup>
-			<FileWrites Condition="Exists('@(_InheritDocBackupFile)')" Include="@(_InheritDocBackupFile)" />
+			<FileWrites Condition="Exists('@(FinalDocFile)')" Include="@(FinalDocFile)" />
 			<InheritDocReference Condition="'$(TargetFramework)'=='netstandard2.0'" Include="$(_InheritDocNetStandardFallback)" />
 		</ItemGroup>
 
-		<InheritDocTask AssemblyPath="@(IntermediateAssembly)" InDocPath="@(_InheritDocBackupFile)" OutDocPath="@(DocFileItem)" RefAssemblyPaths="@(_ResolveAssemblyReferenceResolvedFiles)" AdditionalDocPaths="@(InheritDocReference)" NoWarn="$(NoWarn)" TrimLevel="$(InheritDocTrimLevel)" />
+		<InheritDocTask AssemblyPath="@(IntermediateAssembly)" InDocPath="@(DocFileItem)" OutDocPath="@(FinalDocFile)" RefAssemblyPaths="@(_ResolveAssemblyReferenceResolvedFiles)" AdditionalDocPaths="@(InheritDocReference)" NoWarn="$(NoWarn)" TrimLevel="$(InheritDocTrimLevel)" />
 
 	</Target>
 

--- a/src/InheritDoc/package/build/SauceControl.InheritDoc.targets
+++ b/src/InheritDoc/package/build/SauceControl.InheritDoc.targets
@@ -6,10 +6,10 @@
 		<CopyDocumentationFileToOutputDirectory Condition=" '$(InheritDocEnabled)' == 'true' ">false</CopyDocumentationFileToOutputDirectory>
 	</PropertyGroup>
 
-	<ItemGroup Condition=" '$(InheritDocEnabled)' == 'true' ">
+	<ItemGroup Condition="'$(InheritDocEnabled)'=='true' and '@(DocFileItem)'=='@(FinalDocFile)'">
 		<!-- Force intermediate documentation file -->
-		<DocFileItem Remove="$(DocumentationFile)"/>
-		<DocFileItem Include="$(IntermediateOutputPath)$(AssemblyName).xml"/>
+		<DocFileItem Remove="@(DocFileItem)"/>
+		<DocFileItem Include="@(FinalDocFile->'$(IntermediateOutputPath)%(Filename)%(Extension)')"/>
 	</ItemGroup>
 
 	<Target Name="_InheritDocPostProcess" AfterTargets="CoreCompile" DependsOnTargets="ResolveAssemblyReferences;CoreCompile;_CheckForCompileOutputs" Inputs="@(DocFileItem)" Outputs="@(FinalDocFile)" Condition="'$(InheritDocEnabled)'=='true' and '$(_DocumentationFileProduced)'=='true'">


### PR DESCRIPTION
Set the `CopyDocumentationFileToOutputDirectory` property to `false` and use both the `DocFileItem` and `FinalDocFile` items instead of an extra backup copy. This addresses issue #12.